### PR TITLE
chore: 빌드 버전 정렬 및 코드 정리

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group 'com.rsupport'
-version '1.0.4.0'
+version '1.1.0'
 
 repositories {
     mavenCentral()

--- a/src/main/java/com/rsupport/stringtable/Sheet2Strings.kt
+++ b/src/main/java/com/rsupport/stringtable/Sheet2Strings.kt
@@ -26,8 +26,6 @@ object Sheet2Strings {
         val nav = SheetNavigator(sheet)
         val (columnStringId, rowStringId) = findIdCell(nav, rowPositionColumnHeader)
 
-        var column = columnStringId
-
         val xmlFileName = "$outputXmlFileName.xml"
             .replace(".xml.xml", ".xml")
 
@@ -105,7 +103,7 @@ object Sheet2Strings {
 
         while (true) {
             try {
-                if (isIdColumn(nav.getCell(rowIndex, columnIndex).toLowerCase())) {
+                if (isIdColumn(nav.getCell(rowIndex, columnIndex).lowercase())) {
                     return Pair(columnIndex, rowIndex)
                 } else {
                     columnIndex++
@@ -229,14 +227,9 @@ object Sheet2Strings {
             val file = File(filename)
             if (file.parentFile.isDirectory == false) file.parentFile.mkdirs() else if (file.exists()) file.delete()
 
-            // 4. 파일에 출력
-            val writer = OutputStreamWriter(
-                FileOutputStream(File(filename)),
-                "UTF-8"
-            )
-            //FileWriter writer = new FileWriter(filename);
-            XMLOutputter(Format.getPrettyFormat().setIndent("    ").setEncoding("UTF-8")).output(doc, writer)
-            writer.close()
+            OutputStreamWriter(FileOutputStream(file), "UTF-8").use { writer ->
+                XMLOutputter(Format.getPrettyFormat().setIndent("    ").setEncoding("UTF-8")).output(doc, writer)
+            }
         } catch (e: IOException) {
             e.printStackTrace()
         }

--- a/src/main/java/com/rsupport/stringtable/StringTableGenerator.kt
+++ b/src/main/java/com/rsupport/stringtable/StringTableGenerator.kt
@@ -22,18 +22,19 @@ object StringTableGenerator {
         println("\tres: $resPath")
         val sourceFile = File(source)
         val pathRes = File(resPath)
-        val inputStream = FileInputStream(sourceFile)
-        val workbook = XSSFWorkbook(inputStream)
-        Sheet2Strings.convert(
-            sheet = getTargetSheet(targetSheetName, workbook),
-            pathRes = pathRes,
-            rowPositionColumnHeader = rowPositionColumnHeader,
-            defaultLanguageForValues = defaultLanguageForValues,
-            outputXmlFileName = xmlFileName,
-            doNotConvertNewLine = doNotConvertNewLine,
-        )
+        FileInputStream(sourceFile).use { inputStream ->
+            XSSFWorkbook(inputStream).use { workbook ->
+                Sheet2Strings.convert(
+                    sheet = getTargetSheet(targetSheetName, workbook),
+                    pathRes = pathRes,
+                    rowPositionColumnHeader = rowPositionColumnHeader,
+                    defaultLanguageForValues = defaultLanguageForValues,
+                    outputXmlFileName = xmlFileName,
+                    doNotConvertNewLine = doNotConvertNewLine,
+                )
+            }
+        }
         println("Completed.")
-        inputStream.close()
     }
 
     private fun getTargetSheet(targetSheetName: String?, workbook: XSSFWorkbook): XSSFSheet {


### PR DESCRIPTION
## Summary
- `build.gradle`의 `version` 값을 README/릴리즈 태그(`1.1.0`)와 맞춤 (기존 `1.0.4.0`)
- Kotlin `String.toLowerCase()` deprecated 경고 제거 → `lowercase()` 사용
- `Sheet2Strings.convert` 내 어디에서도 참조되지 않는 `var column` 제거
- `FileInputStream`, `OutputStreamWriter`를 `use { }`로 감싸 IOException 발생 시에도 리소스 close 보장

## Test plan
- [x] `./gradlew compileKotlin compileTestKotlin` 컴파일 경고 없이 성공 확인
- [x] `./gradlew test` — credentials.json 없는 환경에서 전체 테스트 통과 (`Assume`으로 스킵되는 Google API 의존 테스트 제외)
- [ ] 후속 릴리즈 시 JitPack 빌드 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)